### PR TITLE
Add Kaiyo to list of companies

### DIFF
--- a/src/data.yaml
+++ b/src/data.yaml
@@ -1477,6 +1477,19 @@ jobs:
         long: 13.4082116
     review:
     rating:
+  - name: Kaiyo
+    website: https://kaiyo.com
+    jobs: https://kaiyo.com/careers
+    description: Used-Furniture marketplace
+    remote: false
+    speculative: false
+    field: Circular Economy
+    geo:
+      - country: USA
+        lat: 40.7831
+        long: 73.9712
+    review:
+    rating:
 jobportals:
   - name: eejobs.de
     website: https://www.eejobs.de/


### PR DESCRIPTION
I work at Kaiyo. We're hiring software engineers and are focused on making the furniture industry more sustainable by making it more circular. We pick up furniture and deliver it and make it super easy for our customer to participate in the circular economy. I'd love to get the word out to engineers that want to make an impact on reducing waste and carbon emissions!