### PR TITLE
Add DrumRole to job portals

### DIFF
--- a/src/data.yaml
+++ b/src/data.yaml
@@ -2216,3 +2216,6 @@ jobportals:
   - name: Climate Change Jobs
     website: https://climatechangejobs.co.uk/
     country: UK
+  - name: DrumRole
+    website: https://www.drumrole.co/
+    country: Europe


### PR DESCRIPTION
Hey,

I've added DrumRole.co to the job portals. 

DrumRole has jobs with an environmental and social focus in Europe. New jobs are added daily, and old ones removed. And you can read about how greenwashing is avoided [here](https://www.drumrole.co/blog/how-drumrole-selects-companies).

Let me know if you have any questions - happy to help!